### PR TITLE
feat: Add RemoteSwitch showing deletion profile status 

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -444,6 +444,9 @@ profile:
   data:
     title: Your data
     subtitle: Here you will find your personal and contact data used by the IO app.
+    deletion:
+      title:  Delete profile
+      description: Toggle this option to delete your profile and all your data from the IO app.
     list:
       email: Email address
       need_validate: To be validated

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -444,6 +444,9 @@ profile:
   data:
     title: I tuoi dati
     subtitle: Qui trovi i tuoi dati anagrafici e di contatto utilizzati da app IO
+    deletion:
+      title: Elimina profilo
+      description: Abilita questa opzione per eliminare il profilo e tutti i tuoi dati dall'app IO.
     list:
       email: Indirizzo email
       need_validate: Da validare

--- a/ts/screens/profile/NewProfileScreen.tsx
+++ b/ts/screens/profile/NewProfileScreen.tsx
@@ -22,6 +22,9 @@ import GenericErrorComponent from "../../components/screens/GenericErrorComponen
 import { useIOSelector } from "../../store/hooks";
 import { InitializedProfile } from "../../../definitions/backend/InitializedProfile";
 import { getPrintableValueFromPot } from "../../utils/pot";
+import { PreferencesListItem } from "../../components/PreferencesListItem";
+import { RemoteSwitch } from "../../components/core/selection/RemoteSwitch";
+import { isUserDataProcessingDeleteSelector } from "../../store/reducers/userDataProcessing";
 
 const newProfileScreenIconProps: IconProps = {
   name: "io-profilo",
@@ -34,6 +37,9 @@ const NewProfileScreen = () => {
   const dispatch = useDispatch();
 
   const newProfilePot = useIOSelector(newProfileSelector);
+  const isUserDataProcessingDeletePot = useIOSelector(
+    isUserDataProcessingDeleteSelector
+  );
 
   useOnFirstRender(() => {
     loadProfile();
@@ -98,8 +104,12 @@ const NewProfileScreen = () => {
           subTitle={getValueFromNewProfilePot("email")}
           leftIcon={EmailIcon}
           hideIcon
-          isLastItem
           testID="email"
+        />
+        <PreferencesListItem
+          title={I18n.t("profile.data.deletion.title")}
+          description={I18n.t("profile.data.deletion.description")}
+          rightElement={<RemoteSwitch value={isUserDataProcessingDeletePot} />}
         />
       </NBList>
     </ScreenContent>

--- a/ts/screens/profile/NewProfileScreen.tsx
+++ b/ts/screens/profile/NewProfileScreen.tsx
@@ -24,6 +24,8 @@ import { InitializedProfile } from "../../../definitions/backend/InitializedProf
 import { getPrintableValueFromPot } from "../../utils/pot";
 import { PreferencesListItem } from "../../components/PreferencesListItem";
 import { RemoteSwitch } from "../../components/core/selection/RemoteSwitch";
+import { loadUserDataProcessing } from "../../store/actions/userDataProcessing";
+import { UserDataProcessingChoiceEnum } from "../../../definitions/backend/UserDataProcessingChoice";
 import { isUserDataProcessingDeleteSelector } from "../../store/reducers/userDataProcessing";
 
 const newProfileScreenIconProps: IconProps = {
@@ -50,6 +52,9 @@ const NewProfileScreen = () => {
    */
   const loadProfile = () => {
     dispatch(loadNewProfile.request());
+    dispatch(
+      loadUserDataProcessing.request(UserDataProcessingChoiceEnum.DELETE)
+    );
   };
 
   /**

--- a/ts/store/reducers/userDataProcessing.ts
+++ b/ts/store/reducers/userDataProcessing.ts
@@ -1,5 +1,9 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
+import { UserDataProcessingStatusEnum } from "../../../definitions/backend/UserDataProcessingStatus";
 import { UserDataProcessing } from "../../../definitions/backend/UserDataProcessing";
 import { UserDataProcessingChoiceEnum } from "../../../definitions/backend/UserDataProcessingChoice";
 import { computedProp } from "../../types/utils";
@@ -95,3 +99,19 @@ export default userDataProcessingReducer;
 // Selectors
 export const userDataProcessingSelector = (state: GlobalState) =>
   state.userDataProcessing;
+
+export const isUserDataProcessingDeleteSelector = createSelector(
+  [userDataProcessingSelector],
+  (userDataProcessing): pot.Pot<boolean, Error> =>
+    pot.map(userDataProcessing.DELETE, userDataProcessingDelete =>
+      pipe(
+        userDataProcessingDelete,
+        O.fromNullable,
+        O.fold(
+          () => false,
+          dataProcessing =>
+            dataProcessing.status === UserDataProcessingStatusEnum.PENDING
+        )
+      )
+    )
+);


### PR DESCRIPTION
<h3 align="center">⚠️ This PR depends on #1 ⚠️</h3>
<p align="center">Please review first #1 in order to avoid duplicate review work </p>

## Short description
This PR introduces a Switch into `NewProfileScreen` that indicates the deletion profile status, if the user previously requested a profile deletion and the request is PENDING it is toggled, otherwise it is untoggled.

## List of changes proposed in this pull request
- Added `RemoteSwitch` component into `ProfileContentView` sub-component into main screen;
- Added a `isUserDataProcessingDeleteSelector` memoized selector which returns a pot that is true if the deletion process status is _PENDING_ otherwise it is false
- Added localized labels into _it_ and _en_ language

## How to test
- Run the app on the emulator/simulator;
- Login into the app;
- Press on the _profile_ bottom tab;
- Actually there is not a "profile deletion flow request", so you can check only if in the first render of the Screen you are able to see a spinner indicator where is placed the RemoteSwitch

## Preview
<p align="center">
<img src="https://github.com/Hantex9/io-app/assets/34343582/916f024d-76c2-4408-9b6e-101f2d7ab8e2" width="250" />
</p>